### PR TITLE
Removed context dependency to fix script usage

### DIFF
--- a/range_scanner/scanners/generic.py
+++ b/range_scanner/scanners/generic.py
@@ -301,12 +301,6 @@ def startScan(context, dependencies_installed, properties, objectName):
 
             angularFractionPerFrame = properties.fovX
 
-        # save current view mode
-        mode = bpy.context.area.type
-
-        # set view mode to 3D to have all needed variables available
-        bpy.context.area.type = "VIEW_3D"
-
         if properties.scannerType == ScannerType.rotating.name or properties.scannerType == ScannerType.sideScan.name:
             stepsX = properties.xStepDegree
             stepsY = properties.yStepDegree
@@ -393,10 +387,6 @@ def startScan(context, dependencies_installed, properties, objectName):
 
             startIndex += numberOfHits
 
-        # reset view mode
-        bpy.context.area.type = mode
-
-        
         if not properties.exportSingleFrames:
             # we now have the final number of hits so we could shrink the array here
             # as explained here (https://stackoverflow.com/a/32398318/13440564), resizing


### PR DESCRIPTION
When using scripts (see https://github.com/ln-12/blainder-range-scanner/issues/6), the `area` property is not available. Removing it, fixes the crash.