### PR TITLE
Issue 34  - check if material has no links

### DIFF
--- a/range_scanner/material_helper.py
+++ b/range_scanner/material_helper.py
@@ -51,6 +51,10 @@ def getTargetMaterials(debugOutput, target):
                 # instead, we get the Material Output node and look at the connected nodes
                 # see: https://blender.stackexchange.com/a/5471/95167
                 links = material.node_tree.nodes["Material Output"].inputs["Surface"].links
+   
+                if len(links) == 0:
+                    raise ValueError(f"ERROR: Material with name '{material.name}' does not have any links! "
+                                     "Please remove the material or check that the 'Material Output'-node of this material is properly connected. ")
 
                 for link in links:
                     # get the node of the connected link

--- a/range_scanner/scanners/generic.py
+++ b/range_scanner/scanners/generic.py
@@ -240,9 +240,14 @@ def startScan(context, dependencies_installed, properties, objectName):
             else:
                 bpy.ops.object.modifier_apply(apply_as='DATA', modifier=modifier.name)
 
-        targets.append(target)
+        try:
+            targetMaterials = material_helper.getTargetMaterials(properties.debugOutput, target)
+        except ValueError as e:
+            print(e)
+            print(f"The target object with name {target.name} will be ignored! ")
+            continue
 
-        targetMaterials = material_helper.getTargetMaterials(properties.debugOutput, target)
+        targets.append(target)
 
         # get the face->material mappings for the current object
         targetMappings =  material_helper.getFaceMaterialMapping(target.data)


### PR DESCRIPTION
See Issue https://github.com/ln-12/blainder-range-scanner/issues/34 

- I added a check in the `getTargetMaterials` function in 'material_helper.py' to see if a material has no links. 
  - If a material has no links a ValueError will be raised. 
- I added a check in the `startScan` function in generic.py for this ValueError. 
  - In case of a ValueError an error message will be printed and
  - the whole target object will be ignored and
  - the scan will continue

You could remove the second point (check for the ValueError in `startScan` function. 
In that case the user would always know that there is a faulty material (even if he does not have the Blender System Console open) because the scan will fail. 