### PR TITLE
Fix for high memory consumption when working with large textures

### DIFF
--- a/range_scanner/material_helper.py
+++ b/range_scanner/material_helper.py
@@ -74,7 +74,7 @@ def getTargetMaterials(debugOutput, target):
                         if len(connectedLinks) > 0 and connectedLinks[0].from_node.type == "TEX_IMAGE":
                             # image texture
                             image = connectedLinks[0].from_node.image
-                            texture = Image(image.pixels[:], image.size)
+                            texture = Image(np.asarray(image.pixels), image.size)
 
                             # retrieve metallic factor
                             metallic = node.inputs['Metallic'].default_value
@@ -181,7 +181,7 @@ def getUVPixelColor(mesh:Mesh, face_idx:int, point:Vector, image:Image):
     image    -- UV image used as texture for 'mesh' object
     """
     # ensure image contains at least one pixel
-    assert image is not None and image.pixels is not None and len(image.pixels) > 0
+    assert image is not None and image.pixels is not None and image.pixels.size > 0
     
     # get closest material using UV map
     face = mesh.polygons[face_idx]
@@ -255,7 +255,7 @@ def getPixel(uv_pixels, imageSize, uv_coord):
 def getFaceMaterialMapping(mesh):
     # https://blender.stackexchange.com/a/52429/95167
     numberOfPolygons = len(mesh.polygons.items())
-    mapping = np.empty(numberOfPolygons, dtype=int)
+    mapping = np.empty(numberOfPolygons, dtype=np.uint32)
 
     for f in mesh.polygons: 
         mapping[f.index] = f.material_index

--- a/range_scanner/scanners/generic.py
+++ b/range_scanner/scanners/generic.py
@@ -465,5 +465,7 @@ def getBVHTrees(trees, targets, depsgraph):
         bm.transform(target.matrix_world)
         
         trees[target] = (BVHTree.FromBMesh(bm), target.matrix_world.copy())
-    
+
+        bm.free()  # always do this when finished
+
     return trees


### PR DESCRIPTION
Fix for memory leak problems as reported by #33.
By using numpy arrays instead of blender Images to query object textures the memory footprint of the textures can be reduced by an order of magnitude.
The usage of blender's Image type also caused the allocated memory not being freed if an exception was thrown while generating the point clouds.