### PR TITLE
Updated python3.9 to python3.10 in ReadMe to reflect changes in the blender installation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ git clone https://github.com/ln-12/blainder-range-scanner.git
 mkdir ./blender-3.3.5-linux-x64/3.3/scripts/addons_contrib/
 cp -r ./blainder-range-scanner/range_scanner ./blender-3.3.5-linux-x64/3.3/scripts/addons_contrib/
 
-./blender-3.3.5-linux-x64/3.3/python/bin/python3.9 -m ensurepip
-./blender-3.3.5-linux-x64/3.3/python/bin/python3.9 -m pip install -r ./blainder-range-scanner/range_scanner/requirements.txt
+./blender-3.3.5-linux-x64/3.3/python/bin/python3.10 -m ensurepip
+./blender-3.3.5-linux-x64/3.3/python/bin/python3.10 -m pip install -r ./blainder-range-scanner/range_scanner/requirements.txt
 
 ./blender-3.3.5-linux-x64/blender
 ```


### PR DESCRIPTION
When installing from [link](https://download.blender.org/release/Blender3.3/blender-3.3.5-linux-x64.tar.xz) as written in the ReadMe, the installed python version with blender is 3.10 not 3.9. I have changed the installation script in the ReadMe to reflect this. I am new to blender so let me know if I am overlooking something!